### PR TITLE
s;roll improvements

### DIFF
--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -9,10 +9,10 @@ export default class extends SteveCommand {
 		super(store, file, directory, {
 			aliases: ['dice'],
 			description: 'Roll dice!',
-			examples: ['roll 1d6', 'roll 5d10!'],
+			examples: ['roll 1d6', 'roll d20', 'roll 5d10!'],
 			extendedHelp: oneLine`Use standard dice notation. You can add a "!" at the end of your roll to use exploding dice. You can roll
 				up to 10 dice with up to 1,000 sides each.`,
-			usage: '<roll:reg/(?<dice>\\d{1,2})d(?<sides>\\d{1,4})(?<explode>!)?/>',
+			usage: '<roll:reg/(?<dice>\\d{1,2})?d(?<sides>\\d{1,4})(?<explode>!)?/>',
 			helpUsage: '[1-9]d[1-999] (!)'
 		});
 
@@ -22,7 +22,8 @@ export default class extends SteveCommand {
 
 	public async run(msg: KlasaMessage, [match]: [any]): Promise<Message> { // eslint-disable-line @typescript-eslint/no-explicit-any
 		let dice = parseInt(match.groups.dice);
-		dice = dice <= 10 ? dice : 10;
+		if (isNaN(dice)) dice = 1;
+		else dice = dice <= 10 ? dice : 10;
 
 		let sides = parseInt(match.groups.sides);
 		sides = sides <= 1000 ? sides : 1000;

--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -27,7 +27,7 @@ export default class extends SteveCommand {
 		super(store, file, directory, {
 			aliases: ['dice'],
 			description: 'Roll dice!',
-			examples: ['roll 1d6', 'roll d20', 'roll 5d10!', 'roll 1d8|4d6'],
+			examples: ['roll 1d6', 'roll d20', 'roll 5d10!', 'roll 1d8|4d6', 'roll 6d12k1', 'roll 6d12kl2'],
 			extendedHelp: oneLine`Use standard dice notation. You can add a "!" at the end of your roll to use exploding dice. You can roll
 				up to 10 dice with up to 1,000 sides each.`,
 			usage: '<spec:dice> [...]',

--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -33,9 +33,7 @@ export default class extends SteveCommand {
 		const emoji = explodes ? '💥' : '🎲';
 
 		for (let i = 0; i < dice; i++) {
-			let roll = await this.roll(sides);
-
-			if (explodes && roll === sides) roll += await this.roll(sides);
+			const roll = this.roll(sides, explodes);
 
 			finishedRolls.push(roll);
 		}
@@ -43,8 +41,27 @@ export default class extends SteveCommand {
 		return msg.channel.send(`${emoji} You rolled: \`${finishedRolls.join(', ')}\` ${emoji}`);
 	}
 
-	private async roll(num: number): Promise<number> {
-		return Math.floor(Math.random() * num) + 1;
+	private rollOnce(sides: number): number {
+		return Math.floor(Math.random() * sides) + 1;
+	}
+
+	private roll(sides: number, explodes: boolean): number {
+		if (sides <= 1) return 1; // this one is easy
+
+		if (explodes) {
+			let total = 0;
+			let roll = 0;
+			do {
+				roll = this.rollOnce(sides);
+				total += roll;
+			} while (
+				roll === sides
+				&& roll < 1e6 // prevent an infinite loop, just in case
+			);
+			return total;
+		} else {
+			return this.rollOnce(sides);
+		}
 	}
 
 }

--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -28,10 +28,12 @@ export default class extends SteveCommand {
 			aliases: ['dice'],
 			description: 'Roll dice!',
 			examples: ['roll 1d6', 'roll d20', 'roll 5d10!', 'roll 1d8|4d6', 'roll 6d12k1', 'roll 6d12kl2'],
-			extendedHelp: oneLine`Use standard dice notation. You can add a "!" at the end of your roll to use exploding dice. You can roll
-				up to 10 dice with up to 1,000 sides each.`,
+			extendedHelp: oneLine`Use standard dice notation. You can roll up to 10 dice with up to 1,000 sides each.
+				Add a \`!\` at the end of your roll to use exploding dice.
+				To keep the highest n, add \`k<n>\`; to keep the lowest n, add \`kl<n>\` (with n < amount of dice).
+				You can do multiple rolls at once, separated by \`|\`.`,
 			usage: '<spec:dice> [...]',
-			helpUsage: '[1-9]d[1-999] (!)'
+			helpUsage: '<number of dice>d<number of sides>'
 		});
 
 		this.customizeResponse('roll', 'You can roll up to 10 dice with up to 1,000 sides each.');

--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -3,42 +3,77 @@ import { CommandStore, KlasaMessage } from 'klasa';
 import { Message } from 'discord.js';
 import { oneLine } from 'common-tags';
 
+const DICE_REGEX = /(?<count>\d{1,2})?d(?<sides>\d{1,4})(?<explode>!)?/;
+
+interface RollSpec {
+	input: string;
+	count: number;
+	sides: number;
+	explodes: boolean;
+}
+
+interface DiceResult {
+	spec: RollSpec;
+	rolls: number[];
+}
+
 export default class extends SteveCommand {
 
 	public constructor(store: CommandStore, file: string[], directory: string) {
 		super(store, file, directory, {
 			aliases: ['dice'],
 			description: 'Roll dice!',
-			examples: ['roll 1d6', 'roll d20', 'roll 5d10!'],
+			examples: ['roll 1d6', 'roll d20', 'roll 5d10!', 'roll 1d8|4d6'],
 			extendedHelp: oneLine`Use standard dice notation. You can add a "!" at the end of your roll to use exploding dice. You can roll
 				up to 10 dice with up to 1,000 sides each.`,
-			usage: '<roll:reg/(?<dice>\\d{1,2})?d(?<sides>\\d{1,4})(?<explode>!)?/>',
+			usage: '<spec:dice> [...]',
 			helpUsage: '[1-9]d[1-999] (!)'
 		});
 
-		this
-			.customizeResponse('roll', 'You can roll up to 10 dice with up to 1,000 sides each.');
+		this.customizeResponse('roll', 'You can roll up to 10 dice with up to 1,000 sides each.');
+
+		this.createCustomResolver('dice', (arg): RollSpec => {
+			const match = DICE_REGEX.exec(arg);
+
+			let count = parseInt(match.groups.count) ?? 1;
+			if (isNaN(count)) count = 1;
+			else if (count > 10) count = 10;
+
+			let sides = parseInt(match.groups.sides);
+			if (sides > 1000) sides = 1000;
+
+			const explodes = match.groups.explode === '!';
+
+			return { input: match.input, count, sides, explodes };
+		});
 	}
 
-	public async run(msg: KlasaMessage, [match]: [any]): Promise<Message> { // eslint-disable-line @typescript-eslint/no-explicit-any
-		let dice = parseInt(match.groups.dice);
-		if (isNaN(dice)) dice = 1;
-		else dice = dice <= 10 ? dice : 10;
+	public async run(msg: KlasaMessage, specs: RollSpec[]): Promise<Message> {
+		const results: DiceResult[] = [];
 
-		let sides = parseInt(match.groups.sides);
-		sides = sides <= 1000 ? sides : 1000;
+		for (const spec of specs) {
+			const rolls = [];
+			for (let i = 0; i < spec.count; i++) {
+				const roll = this.roll(spec.sides, spec.explodes);
+				rolls.push(roll);
+			}
 
-		const explodes = match.groups.explode === '!';
-		const finishedRolls = [];
-		const emoji = explodes ? '💥' : '🎲';
-
-		for (let i = 0; i < dice; i++) {
-			const roll = this.roll(sides, explodes);
-
-			finishedRolls.push(roll);
+			results.push({ spec, rolls });
 		}
 
-		return msg.channel.send(`${emoji} You rolled: \`${finishedRolls.join(', ')}\` ${emoji}`);
+		if (results.length === 1) {
+			const result = results[0];
+			const emoji = result.spec.explodes ? '💥' : '🎲';
+			const message = `${emoji} You rolled: \`${result.rolls.join(', ')}\` ${emoji}`;
+			return msg.channel.send(message);
+		} else {
+			let message = 'You rolled:';
+			for (const result of results) {
+				const emoji = result.spec.explodes ? '💥' : '🎲';
+				message += `\n${emoji} ${result.spec.input}: \`${result.rolls.join(', ')}\``;
+			}
+			return msg.channel.send(message);
+		}
 	}
 
 	private rollOnce(sides: number): number {

--- a/src/commands/Fun/Random/roll.ts
+++ b/src/commands/Fun/Random/roll.ts
@@ -39,11 +39,11 @@ export default class extends SteveCommand {
 		this.createCustomResolver('dice', (arg): RollSpec => {
 			const match = DICE_REGEX.exec(arg);
 
-			let count = parseInt(match.groups.count) ?? 1;
+			let count = parseInt(match.groups.count, 10) ?? 1;
 			if (isNaN(count)) count = 1;
 			else if (count > 10) count = 10;
 
-			let sides = parseInt(match.groups.sides);
+			let sides = parseInt(match.groups.sides, 10);
 			if (sides > 1000) sides = 1000;
 
 			const explodes = match.groups.explode === '!';
@@ -55,7 +55,7 @@ export default class extends SteveCommand {
 				else keep = 'highest';
 			}
 
-			const keepCount = parseInt(match.groups.keepCount);
+			const keepCount = parseInt(match.groups.keepCount, 10);
 
 			return { input: match.input, count, sides, explodes, keep, keepCount };
 		});


### PR DESCRIPTION
Fixes #1.

- [x] `s;roll 1d8|4d6` Roll multiple dice at once
- [x] `s;roll 2d20k1` Roll multiple dice, keep highest _n_
- [x] `s;roll 2d20kl1` Roll multiple dice, keep lowest _n_
- [x] `s;roll d20` Infer the dice count to be 1 if omitted

Also fixes exploding dice: the current code only explodes once even if the max value is rolled twice. The proposed code will keep exploding repeatedly if possible.