### PR TITLE
discordstatus command

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "module-alias": "^2.2.2",
     "moment": "^2.24.0",
     "mongodb": "^3.5.3",
+    "node-fetch": "^2.6.1",
     "pretty-ms": "^6.0.1"
   },
   "_moduleAliases": {

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -2,7 +2,7 @@ import { SteveCommand } from '@lib/structures/commands/SteveCommand';
 import { CommandStore, KlasaMessage } from 'klasa';
 import { Message, MessageEmbed } from 'discord.js';
 import { formatDate } from '@utils/util';
-import fetch from 'node-fetch'
+import fetch from 'node-fetch';
 
 export default class extends SteveCommand {
 
@@ -18,20 +18,20 @@ export default class extends SteveCommand {
 	public async run(msg: KlasaMessage): Promise<Message> {
 		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
 
-		return fetch(url, { method: "Get" })
+		return fetch(url, { method: 'Get' })
 			.then(res => res.json())
-			.then((json) => {
+			.then(json => {
 				const embed = new MessageEmbed()
-				.setTitle(json.status.description)
-				.setDescription(msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION', json.status.indicator))
-				.addFields(json.components.map((component: { name: any; status: any; }) => ({
-					name: component.name,
-					value: component.status,
-					inline: true
-				})))
-				.setFooter(msg.language.tget('COMMAND_DISCORD_STATUS_EMBED_FOOTER', formatDate(json.page.updated_at)));
+					.setTitle(json.status.description)
+					.setDescription(msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION', json.status.indicator))
+					.addFields(json.components.map((component: { name: any; status: any }) => ({
+						name: component.name,
+						value: component.status,
+						inline: true
+					})))
+					.setFooter(msg.language.tget('COMMAND_DISCORD_STATUS_EMBED_FOOTER', formatDate(json.page.updated_at)));
 
-			return msg.channel.send(embed);
+				return msg.channel.send(embed);
 			});
 	}
 

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -17,19 +17,20 @@ export default class extends SteveCommand {
 
 	public async run(msg: KlasaMessage): Promise<Message> {
 		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
+		const EMBED_DATA = msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED')
 
 		return fetch(url, { method: 'Get' })
 			.then(res => res.json())
 			.then(json => {
 				const embed = new MessageEmbed()
 					.setTitle(json.status.description)
-					.setDescription(msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION', json.status.indicator))
+					.setDescription(EMBED_DATA.DECRIPTION(json.status.indicator))
 					.addFields(json.components.map((component: { name: any; status: any }) => ({
 						name: component.name,
 						value: component.status,
 						inline: true
 					})))
-					.setFooter(msg.language.tget('COMMAND_DISCORD_STATUS_EMBED_FOOTER', formatDate(json.page.updated_at)));
+					.setFooter(EMBED_DATA.FOOTER(formatDate(json.page.updated_at)));
 
 				return msg.channel.send(embed);
 			});

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -11,7 +11,7 @@ export default class extends SteveCommand {
 			aliases: ['ds', 'discstatus', 'isdiscordbroke'],
 			cooldown: 60,
 			cooldownLevel: 'channel',
-			description: 'See the current status of Discord'
+			description: lang => lang.tget('COMMAND_DISCORD_STAUTS_DECRIPTION')
 		});
 	}
 
@@ -23,14 +23,13 @@ export default class extends SteveCommand {
 			.then((json) => {
 				const embed = new MessageEmbed()
 				.setTitle(json.status.description)
-				.setDescription(`[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${json.status.indicator}`)
+				.setDescription(msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION', json.status.indicator))
 				.addFields(json.components.map((component: { name: any; status: any; }) => ({
 					name: component.name,
 					value: component.status,
 					inline: true
 				})))
-				.setTimestamp()
-				.setFooter(`Last changed: ${formatDate(json.page.updated_at)}`);
+				.setFooter(msg.language.tget('COMMAND_DISCORD_STATUS_EMBED_FOOTER', formatDate(json.page.updated_at)));
 
 			return msg.channel.send(embed);
 			});

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -33,6 +33,10 @@ export default class extends SteveCommand {
 					.setFooter(EMBED_DATA.FOOTER(formatDate(json.page.updated_at)));
 
 				return msg.channel.send(embed);
+			})
+			.catch(err => {
+				console.log(err);
+				return msg.sendLocale('COMMAND_DSICORD_STATUS_ERROR');
 			});
 	}
 

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -11,7 +11,7 @@ export default class extends SteveCommand {
 			aliases: ['ds', 'discstatus', 'isdiscordbroke'],
 			cooldown: 60,
 			cooldownLevel: 'channel',
-			description: lang => lang.tget('COMMAND_DISCORD_STAUTS_DECRIPTION')
+			description: lang => lang.tget('COMMAND_DISCORD_STATUS_DESCRIPTION')
 		});
 	}
 
@@ -36,7 +36,7 @@ export default class extends SteveCommand {
 			})
 			.catch(err => {
 				console.log(err);
-				return msg.sendLocale('COMMAND_DSICORD_STATUS_ERROR');
+				return msg.sendLocale('COMMAND_DISCORD_STATUS_ERROR');
 			});
 	}
 

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -1,0 +1,39 @@
+import { SteveCommand } from '@lib/structures/commands/SteveCommand';
+import { CommandStore, KlasaMessage } from 'klasa';
+import { Message, MessageEmbed } from 'discord.js';
+import { formatDate } from '@utils/util';
+import fetch from 'node-fetch'
+
+export default class extends SteveCommand {
+
+	public constructor(store: CommandStore, file: string[], directory: string) {
+		super(store, file, directory, {
+			aliases: ['ds', 'discstatus', 'isdiscordbroke'],
+			cooldown: 60,
+			cooldownLevel: 'channel',
+			description: 'See the current status of Discord'
+		});
+	}
+
+	public async run(msg: KlasaMessage): Promise<Message> {
+		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
+
+		return fetch(url, { method: "Get" })
+			.then(res => res.json())
+			.then((json) => {
+				const embed = new MessageEmbed()
+				.setTitle(json.status.description)
+				.setDescription(`[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${json.status.indicator}`)
+				.addFields(json.components.map((component: { name: any; status: any; }) => ({
+					name: component.name,
+					value: component.status,
+					inline: true
+				})))
+				.setTimestamp()
+				.setFooter(`Last changed: ${formatDate(json.page.updated_at)}`);
+
+			return msg.channel.send(embed);
+			});
+	}
+
+}

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -17,7 +17,7 @@ export default class extends SteveCommand {
 
 	public async run(msg: KlasaMessage): Promise<Message> {
 		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
-		const EMBED_DATA = msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED')
+		const EMBED_DATA = msg.language.tget('COMMAND_DISCORD_STAUTS_EMBED');
 
 		return fetch(url, { method: 'Get' })
 			.then(res => res.json())

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -317,6 +317,7 @@ export default class extends Language {
 			TITLE: 'Statistics'
 		},
 		COMMAND_DISCORD_STAUTS_DECRIPTION: 'See the current status of Discord.',
+		COMMAND_DSICORD_STATUS_ERROR: 'An error occured when attempting to fetch Discord\'s status.',
 		COMMAND_DISCORD_STAUTS_EMBED: {
 			DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
 			FOOTER: (time): string => `Last changed: ${time} | ${this.randomDftba}`	

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -317,8 +317,10 @@ export default class extends Language {
 			TITLE: 'Statistics'
 		},
 		COMMAND_DISCORD_STAUTS_DECRIPTION: 'See the current status of Discord.',
-		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
-		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time): string => `Last changed: ${time} • ${this.randomDftba}`,
+		COMMAND_DISCORD_STAUTS_EMBED: {
+			DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
+			FOOTER: (time): string => `Last changed: ${time} | ${this.randomDftba}`	
+		},
 		MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',
 		TEXT_PROMPT_ABORT_OPTIONS: ['abort', 'stop', 'cancel'],
 		/**

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -316,8 +316,8 @@ export default class extends Language {
 			FOOTER: this.randomDftba,
 			TITLE: 'Statistics'
 		},
-		COMMAND_DISCORD_STAUTS_DECRIPTION: 'See the current status of Discord.',
-		COMMAND_DSICORD_STATUS_ERROR: 'An error occured when attempting to fetch Discord\'s status.',
+		COMMAND_DISCORD_STATUS_DESCRIPTION: 'See the current status of Discord.',
+		COMMAND_DISCORD_STATUS_ERROR: 'An error occured when attempting to fetch Discord\'s status.',
 		COMMAND_DISCORD_STAUTS_EMBED: {
 			DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
 			FOOTER: (time): string => `Last changed: ${time} | ${this.randomDftba}`

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -317,8 +317,8 @@ export default class extends Language {
 			TITLE: 'Statistics'
 		},
 		COMMAND_DISCORD_STAUTS_DECRIPTION: 'See the current status of Discord.',
-		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident):string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
-		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time):string => `Last changed: ${time} • ${this.randomDftba}`,
+		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
+		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time): string => `Last changed: ${time} • ${this.randomDftba}`,
 		MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',
 		TEXT_PROMPT_ABORT_OPTIONS: ['abort', 'stop', 'cancel'],
 		/**

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -320,7 +320,7 @@ export default class extends Language {
 		COMMAND_DSICORD_STATUS_ERROR: 'An error occured when attempting to fetch Discord\'s status.',
 		COMMAND_DISCORD_STAUTS_EMBED: {
 			DECRIPTION: (incident): string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
-			FOOTER: (time): string => `Last changed: ${time} | ${this.randomDftba}`	
+			FOOTER: (time): string => `Last changed: ${time} | ${this.randomDftba}`
 		},
 		MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',
 		TEXT_PROMPT_ABORT_OPTIONS: ['abort', 'stop', 'cancel'],

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -316,6 +316,9 @@ export default class extends Language {
 			FOOTER: this.randomDftba,
 			TITLE: 'Statistics'
 		},
+		COMMAND_DISCORD_STAUTS_DECRIPTION: 'See the current status of Discord.',
+		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident):string => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
+		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time):string => `Last changed: ${time} • ${this.randomDftba}`,
 		MESSAGE_PROMPT_TIMEOUT: 'The prompt has timed out.',
 		TEXT_PROMPT_ABORT_OPTIONS: ['abort', 'stop', 'cancel'],
 		/**

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -138,6 +138,9 @@ declare module 'klasa' {
 			FOOTER: string;
 			TITLE: string;
 		};
+		COMMAND_DISCORD_STAUTS_DECRIPTION: string;
+		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident: string) => string;
+		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time: string) => string;
 		MESSAGE_PROMPT_TIMEOUT: string;
 		TEXT_PROMPT_ABORT_OPTIONS: string[];
 		USER_NOT_IN_GUILD: (user: string) => string;

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -138,8 +138,8 @@ declare module 'klasa' {
 			FOOTER: string;
 			TITLE: string;
 		};
-		COMMAND_DISCORD_STAUTS_DECRIPTION: string;
-		COMMAND_DSICORD_STATUS_ERROR: string;
+		COMMAND_DISCORD_STATUS_DESCRIPTION: string;
+		COMMAND_DISCORD_STATUS_ERROR: string;
 		COMMAND_DISCORD_STAUTS_EMBED: {
 			DECRIPTION: (incident: string) => string;
 			FOOTER: (time: string) => string;

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -139,8 +139,10 @@ declare module 'klasa' {
 			TITLE: string;
 		};
 		COMMAND_DISCORD_STAUTS_DECRIPTION: string;
-		COMMAND_DISCORD_STAUTS_EMBED_DECRIPTION: (incident: string) => string;
-		COMMAND_DISCORD_STATUS_EMBED_FOOTER: (time: string) => string;
+		COMMAND_DISCORD_STAUTS_EMBED: {
+			DECRIPTION: (incident: string) => string;
+			FOOTER: (time: string) => string;
+		};
 		MESSAGE_PROMPT_TIMEOUT: string;
 		TEXT_PROMPT_ABORT_OPTIONS: string[];
 		USER_NOT_IN_GUILD: (user: string) => string;

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -139,6 +139,7 @@ declare module 'klasa' {
 			TITLE: string;
 		};
 		COMMAND_DISCORD_STAUTS_DECRIPTION: string;
+		COMMAND_DSICORD_STATUS_ERROR: string;
 		COMMAND_DISCORD_STAUTS_EMBED: {
 			DECRIPTION: (incident: string) => string;
 			FOOTER: (time: string) => string;


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR adds the discordstatus command (aliases: ds, discstatus, isdiscordbroke). The command pulls information from https://srhpyqt94yxb.statuspage.io/api/v2/summary.json and formats it into a nice neat embed for the users viewing pleasure. It also adds node-fetch as a dependency to do this.
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [x] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
