### PR TITLE
[FIX] error when running snip command with no args

### DIFF
--- a/src/commands/Snippets/snippet.ts
+++ b/src/commands/Snippets/snippet.ts
@@ -59,6 +59,10 @@ export default class extends SteveCommand {
 	}
 
 	public async view(msg: KlasaMessage, [snipName]: [string]): Promise<Message> {
+		if (!snipName) {
+			return this.list(msg);
+		}
+
 		const snips: Snippet[] = msg.guild!.settings.get(GuildSettings.Snippets);
 
 		const snip = snips.find(s => s.name === snipName.toLowerCase());


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR fixes the error that occurs when running the snippet command with no args. Instead of erroring, the command outputs the same thing it would output if it was ran with the list subcommand. Its a single if statement and a call tot he list subcommand.
Resolves #53 
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [x] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [x] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
