### PR TITLE
Proper incident reporting in discordstatus command

### DIFF
--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -24,7 +24,7 @@ export default class extends SteveCommand {
 			.then(json => {
 				const embed = new MessageEmbed()
 					.setTitle(json.status.description)
-					.setDescription(EMBED_DATA.DECRIPTION(json.status.indicator))
+					.setDescription(EMBED_DATA.DECRIPTION(json.incidents[0] ? json.incidents[0].name : 'none'))
 					.addFields(json.components.map((component: { name: any; status: any }) => ({
 						name: component.name,
 						value: component.status,


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
So it turns out that I wasnt grabbing the right part of the json object for the current incident. I didnt really have a way to test it because there was no ongoing incident when I made it but now it grabs the correct information. You can see in the screenshot below how the most recent incident appears.
![](https://cdn.discordapp.com/attachments/723241105323327581/775401991148404766/unknown.png)
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [x] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [ ] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
