### PR TITLE
feat: Random XKCD comic

### DIFF
--- a/src/commands/Fun/xkcd.ts
+++ b/src/commands/Fun/xkcd.ts
@@ -53,9 +53,16 @@ export default class extends SteveCommand {
 	 * @param comic The Xkcd commic used to form the embed
 	 */
 	private createComicEmbed(comic: XkcdComic): MessageEmbed {
+		const description = (comic.transcript || comic.alt)
+			.replace('{{', '{')
+			.replace('}}', '}')
+			.replace('[[', '[')
+			.replace(']]', ']')
+			.replace('<<', '<')
+			.replace('>>', '>');
 		return new MessageEmbed()
 			.setColor(0x2242c7)
-			.setDescription(comic.transcript || comic.alt)
+			.setDescription(description)
 			.setImage(comic.img)
 			.setTimestamp()
 			.setTitle(oneLine`${comic.safe_title} (#${comic.num},

--- a/src/commands/Fun/xkcd.ts
+++ b/src/commands/Fun/xkcd.ts
@@ -54,12 +54,12 @@ export default class extends SteveCommand {
 	 */
 	private createComicEmbed(comic: XkcdComic): MessageEmbed {
 		const description = (comic.transcript || comic.alt)
-			.replace('{{', '{')
-			.replace('}}', '}')
-			.replace('[[', '[')
-			.replace(']]', ']')
-			.replace('<<', '<')
-			.replace('>>', '>');
+			.replace(/{{/g, '{')
+			.replace(/}}/g, '}')
+			.replace(/\[\[/g, '[')
+			.replace(/]]/g, ']')
+			.replace(/<</g, '<')
+			.replace(/>>/g, '>');
 		return new MessageEmbed()
 			.setColor(0x2242c7)
 			.setDescription(`${description}\n\nhttps://xkcd.com/${comic.num}/`)

--- a/src/commands/Fun/xkcd.ts
+++ b/src/commands/Fun/xkcd.ts
@@ -62,7 +62,7 @@ export default class extends SteveCommand {
 			.replace('>>', '>');
 		return new MessageEmbed()
 			.setColor(0x2242c7)
-			.setDescription(description)
+			.setDescription(`${description}\n\nhttps://xkcd.com/${comic.num}/`)
 			.setImage(comic.img)
 			.setTimestamp()
 			.setTitle(oneLine`${comic.safe_title} (#${comic.num},


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR modifies the new XKCD command. It adds subcommands for a random comic (default) and the newest comic. It keeps the ability to specify a comic number in both the random and new subcommand. It also adds `x` as an alias for the command. There is also now some cleaning of the comic transcript as on older commits it isnt super human friendly and I added a link to view the comic on https://xkcd.com/
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [x] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
