### PR TITLE
Upgraded discordstatus command

### DIFF
--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -2,8 +2,8 @@ import { SteveCommand } from '@lib/structures/commands/SteveCommand';
 import { CommandOptions, KlasaMessage } from 'klasa';
 import { EmbedField, Message, MessageEmbed } from 'discord.js';
 import { formatDate } from '@utils/util';
-import fetch from 'node-fetch';
 import { ApplyOptions } from '@skyra/decorators';
+import axios from 'axios';
 
 @ApplyOptions<CommandOptions>({
 	aliases: ['ds', 'discstatus', 'isdiscordbroke'],
@@ -17,9 +17,9 @@ export default class extends SteveCommand {
 		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
 		const embedData = msg.language.tget('commandDiscordStatusEmbed');
 
-		const currentStatus = await fetch(url, { method: 'Get' }).then(r => r.json()) as DiscordStatus;
+		const { data: currentStatus, statusText } = await axios.get<DiscordStatus>(url);
 
-		if (!currentStatus) {
+		if (statusText !== 'OK') {
 			return msg.channel.send(msg.language.tget('commandDiscordStatusError'));
 		}
 

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -1,6 +1,6 @@
 import { SteveCommand } from '@lib/structures/commands/SteveCommand';
 import { CommandOptions, KlasaMessage } from 'klasa';
-import { Message, MessageEmbed } from 'discord.js';
+import { EmbedField, Message, MessageEmbed } from 'discord.js';
 import { formatDate } from '@utils/util';
 import fetch from 'node-fetch';
 import { ApplyOptions } from '@skyra/decorators';
@@ -15,27 +15,121 @@ export default class extends SteveCommand {
 
 	public async run(msg: KlasaMessage): Promise<Message> {
 		const url = 'https://srhpyqt94yxb.statuspage.io/api/v2/summary.json';
-		const embedData = msg.language.tget('commandDiscordStautsEmbed');
+		const embedData = msg.language.tget('commandDiscordStatusEmbed');
 
-		return fetch(url, { method: 'Get' })
-			.then(res => res.json())
-			.then(json => {
-				const embed = new MessageEmbed()
-					.setTitle(json.status.description)
-					.setDescription(embedData.decription(json.status.indicator))
-					.addFields(json.components.map((component: { name: any; status: any }) => ({
+		const currentStatus = await fetch(url, { method: 'Get' }).then(r => r.json()) as DiscordStatus;
+
+		if (!currentStatus) {
+			return msg.channel.send(msg.language.tget('commandDiscordStatusError'));
+		}
+
+		const fields: Array<EmbedField> = [];
+
+		if (currentStatus.components?.every(component => component.status === 'operational')) {
+			fields.push({
+				name: embedData.fields.operational.title,
+				value: embedData.fields.operational.value,
+				inline: false
+			});
+		} else {
+			currentStatus.components.forEach(component => {
+				if (component.status !== 'operational') {
+					fields.push({
 						name: component.name,
 						value: component.status,
 						inline: true
-					})))
-					.setFooter(embedData.footer(formatDate(json.page.updated_at)));
-
-				return msg.channel.send(embed);
-			})
-			.catch(err => {
-				console.log(err);
-				return msg.sendLocale('commandDiscordStatusError');
+					});
+				}
 			});
+		}
+
+		if (currentStatus.scheduled_maintenances.length > 0) {
+			fields.push({
+				name: embedData.fields.maintenance.title,
+				value: currentStatus.scheduled_maintenances.map(m => embedData.fields.maintenance.value(m.name, m.impact)).join('\n'),
+				inline: false
+			});
+		}
+
+		const embed = new MessageEmbed()
+			.setTitle(currentStatus.status.description)
+			.setDescription(embedData.description(currentStatus.incidents[0]
+				? currentStatus.incidents.map(i => i.name).join('\n')
+				: embedData.noIncidents))
+			.addFields(fields)
+			.setThumbnail('https://discord.com/assets/2c21aeda16de354ba5334551a883b481.png')
+			.setTimestamp()
+			.setFooter(embedData.footer(formatDate(new Date(currentStatus.page.updated_at))))
+			.setColor('BLURPLE');
+
+		return msg.channel.send(embed);
+
 	}
 
+}
+
+interface DiscordStatus {
+	page: Page;
+	status: Status;
+	components: (ComponentsEntity)[];
+	incidents: (IncidentsEntity)[];
+	scheduled_maintenances: (ScheduledMaintenancesEntity)[];
+}
+interface Page {
+	id: string;
+	name: string;
+	url: string;
+	updated_at: string;
+}
+interface Status {
+	description: string;
+	indicator: string;
+}
+interface ComponentsEntity {
+	created_at: string;
+	description?: string | null;
+	id: string;
+	name: string;
+	page_id: string;
+	position: number;
+	status: string;
+	updated_at: string;
+	only_show_if_degraded: boolean;
+}
+interface IncidentsEntity {
+	created_at: string;
+	id: string;
+	impact: string;
+	incident_updates?: (IncidentUpdatesEntity)[] | null;
+	monitoring_at?: null;
+	name: string;
+	page_id: string;
+	resolved_at?: null;
+	shortlink: string;
+	status: string;
+	updated_at: string;
+}
+interface IncidentUpdatesEntity {
+	body: string;
+	created_at: string;
+	display_at: string;
+	id: string;
+	incident_id: string;
+	status: string;
+	updated_at: string;
+}
+interface ScheduledMaintenancesEntity {
+	created_at: string;
+	id: string;
+	impact: string;
+	incident_updates?: (IncidentUpdatesEntity)[] | null;
+	monitoring_at?: null;
+	name: string;
+	page_id: string;
+	resolved_at?: null;
+	scheduled_for: string;
+	scheduled_until: string;
+	shortlink: string;
+	status: string;
+	updated_at: string;
 }

--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -23,7 +23,7 @@ export default class extends SteveCommand {
 			return msg.channel.send(msg.language.tget('commandDiscordStatusError'));
 		}
 
-		const fields: Array<EmbedField> = [];
+		const fields: EmbedField[] = [];
 
 		if (currentStatus.components?.every(component => component.status === 'operational')) {
 			fields.push({
@@ -71,9 +71,9 @@ export default class extends SteveCommand {
 interface DiscordStatus {
 	page: Page;
 	status: Status;
-	components: (ComponentsEntity)[];
-	incidents: (IncidentsEntity)[];
-	scheduled_maintenances: (ScheduledMaintenancesEntity)[];
+	components: ComponentsEntity[];
+	incidents: IncidentsEntity[];
+	scheduled_maintenances: ScheduledMaintenancesEntity[];
 }
 interface Page {
 	id: string;
@@ -100,7 +100,7 @@ interface IncidentsEntity {
 	created_at: string;
 	id: string;
 	impact: string;
-	incident_updates?: (IncidentUpdatesEntity)[] | null;
+	incident_updates?: IncidentUpdatesEntity[] | null;
 	monitoring_at?: null;
 	name: string;
 	page_id: string;
@@ -122,7 +122,7 @@ interface ScheduledMaintenancesEntity {
 	created_at: string;
 	id: string;
 	impact: string;
-	incident_updates?: (IncidentUpdatesEntity)[] | null;
+	incident_updates?: IncidentUpdatesEntity[] | null;
 	monitoring_at?: null;
 	name: string;
 	page_id: string;

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -318,9 +318,20 @@ export default class extends Language {
 			title: 'Statistics'
 		},
 		commandDiscordStatusDescription: 'See the current status of Discord.',
-		commandDiscordStatusError: 'An error occured when attempting to fetch Discord\'s status.',
-		commandDiscordStautsEmbed: {
-			decription: incident => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
+		commandDiscordStatusError: 'An error occurred when attempting to fetch Discord\'s status.',
+		commandDiscordStatusEmbed: {
+			description: incident => `[Discord Status](https://discordstatus.com/)\n**Current Incident:**\n${incident}`,
+			noIncidents: 'There is no active incidents.',
+			fields: {
+				operational: {
+					title: 'All components operational',
+					value: 'No errors to report'
+				},
+				maintenance: {
+					title: 'Scheduled Maintenance',
+					value: (name, impact) => `${name} | Impact: ${impact}`
+				}
+			},
 			footer: time => `Last changed: ${time} | ${this.randomDftba}`
 		},
 		messagePromptTimeout: 'The prompt has timed out.',

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -141,8 +141,19 @@ declare module 'klasa' {
 		};
 		commandDiscordStatusDescription: string;
 		commandDiscordStatusError: string;
-		commandDiscordStautsEmbed: {
-			decription: (incident: string) => string;
+		commandDiscordStatusEmbed: {
+			description: (incident: string) => string;
+			noIncidents: string;
+			fields: {
+				operational: {
+					title: string;
+					value: string;
+				};
+				maintenance: {
+					title: string;
+					value: (name: string, impact: string) => string;
+				};
+			};
 			footer: (time: string) => string;
 		};
 		messagePromptTimeout: string;


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR greatly upgrades the discordstatus command. It now takes up much less space, only showing components statuses when they are not operational. It also now shows information on scheduled maintenance if Discord ever decides to schedule any. The upgraded embed now looks like this when all systems are normal and will change as the status changes.
![](https://media.discordapp.net/attachments/723241105323327581/806318907777482782/unknown.png)
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [ ] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
