### PR TITLE
feat (wolfram): added wolfram command

### DIFF
--- a/config.example.ts
+++ b/config.example.ts
@@ -3,7 +3,9 @@ import { KlasaClientOptions } from 'klasa';
 
 export const TOKENS = {
 	BOT_TOKEN: '', // put your bot's token here
-	GENIUS: '' // get a genius api key and put it here (https://docs.genius.com/)
+	GENIUS: '', // get a genius api key and put it here (https://docs.genius.com/)
+	NASA: '',
+	WOLFRAM: '' // get an app id from https://products.wolframalpha.com/api/
 };
 
 export const CLIENT_ID = ''; // put your bot's client id here

--- a/src/commands/Productivity/wolfram.ts
+++ b/src/commands/Productivity/wolfram.ts
@@ -1,0 +1,45 @@
+import { SteveCommand } from '@lib/structures/commands/SteveCommand';
+import { ApplyOptions } from '@skyra/decorators';
+import { CommandOptions, KlasaMessage } from 'klasa';
+import axios from 'axios';
+import { TOKENS } from '@root/config';
+import { MessageEmbed } from 'discord.js';
+
+@ApplyOptions<CommandOptions>({
+	aliases: ['wolfram-alpha', 'math', 'domymathhomework'],
+	cooldown: 30,
+	cooldownLevel: 'author',
+	description: lang => lang.tget('commandWolframDescription'),
+	extendedHelp: lang => lang.tget('commandWolframExtended'),
+	requiredPermissions: ['EMBED_LINKS'],
+	usage: '<query:string>'
+})
+export default class extends SteveCommand {
+
+	public async run(msg: KlasaMessage, [query]: [string]) {
+		const loadingMsg = await msg.channel.send(msg.language.tget('commandWolframLoading'));
+		const url = `http://api.wolframalpha.com/v1/result?appid=${TOKENS.WOLFRAM}&i=${encodeURIComponent(query)}&units=metric`;
+
+		axios.get(url)
+			.then(({ status, data: result }) => {
+				if (status !== 200) throw 'Bad Wolfram request';
+
+				const embedData = msg.language.tget('commandWolframEmbed');
+				return loadingMsg.edit(new MessageEmbed()
+					.setTitle(embedData.title)
+					.setDescription(embedData.description)
+					.addFields([{
+						name: embedData.queryHeader,
+						value: query
+					}, {
+						name: embedData.resultHeader,
+						value: result
+					}])
+					.setFooter(embedData.footer)
+					.setThumbnail('https://media.discordapp.net/attachments/723241105323327581/814368531600637968/wolfram-logo.png')
+					.setColor('0xDD1100'));
+			})
+			.catch(() => loadingMsg.edit(msg.language.tget('commandWolframError')));
+	}
+
+}

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -107,7 +107,7 @@ export default class extends Language {
 		prefixReminder: (prefix = `@${this.client.user!.tag}`) => `The prefix${Array.isArray(prefix)
 			? `es for this server are: ${prefix.map(pre => `\`${pre}\``).join(', ')}`
 			: ` in this server is set to: \`${prefix}\``
-			}`,
+		}`,
 		settingGatewayExpectsGuild: 'The parameter <Guild> expects either a Guild or a Guild Object.',
 		settingGatewayValueForKeyNoext: (data, key) => `The value ${data} for the key ${key} does not exist.`,
 		settingGatewayValueForKeyAlrext: (data, key) => `The value ${data} for the key ${key} already exists.`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -785,7 +785,7 @@ export default class extends Language {
 				'derive 4x^2 + 3x +7'
 			]
 		}),
-		commandWolframLoading: 'Using mad maths skillz...',
+		commandWolframLoading: 'Using mad math skillz...',
 		commandWolframError: 'There was too much math and something went wrong.',
 		commandWolframEmbed: {
 			title: 'The math is done!',

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -107,7 +107,7 @@ export default class extends Language {
 		prefixReminder: (prefix = `@${this.client.user!.tag}`) => `The prefix${Array.isArray(prefix)
 			? `es for this server are: ${prefix.map(pre => `\`${pre}\``).join(', ')}`
 			: ` in this server is set to: \`${prefix}\``
-		}`,
+			}`,
 		settingGatewayExpectsGuild: 'The parameter <Guild> expects either a Guild or a Guild Object.',
 		settingGatewayValueForKeyNoext: (data, key) => `The value ${data} for the key ${key} does not exist.`,
 		settingGatewayValueForKeyAlrext: (data, key) => `The value ${data} for the key ${key} already exists.`,
@@ -773,6 +773,27 @@ export default class extends Language {
 			extendedHelp: 'This command helps facilitate use of the Pomodoro technique; it is currently under reconstruction and thus its functions are not available. Check back soon!'
 		}),
 		commandPomodoroUnderConstruction: 'This command is under reconstruction and is not currently available. Check back soon!',
+		/**
+		 * ################################
+		 * #      WOLFRAM-ALPHA           #
+		 * ################################
+		 */
+		commandWolframDescription: 'Use Wolfram Alpha to do some math.',
+		commandWolframExtended: builder.display('wolfram', {
+			examples: [
+				'(3 + 9) / 7',
+				'derive 4x^2 + 3x +7'
+			]
+		}),
+		commandWolframLoading: 'Using mad maths skillz...',
+		commandWolframError: 'There was too much math and something went wrong.',
+		commandWolframEmbed: {
+			title: 'The math is done!',
+			description: 'Powered by [Wolfram Alpha](https://www.wolframalpha.com/).',
+			queryHeader: 'Your Question',
+			resultHeader: 'The Result',
+			footer: this.randomDftba
+		},
 		/**
 		 * ################################
 		 * #      SELF-ASSIGN             #

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -312,6 +312,17 @@ declare module 'klasa' {
 		commandPomodoroDescription: string;
 		commandPomodoroExtended: string;
 		commandPomodoroUnderConstruction: string;
+		commandWolframDescription: string;
+		commandWolframExtended: string;
+		commandWolframLoading: string;
+		commandWolframError: string;
+		commandWolframEmbed: {
+			title: string;
+			description: string;
+			queryHeader: string;
+			resultHeader: string;
+			footer: string;
+		};
 		commandAddAssignableRoleDescription: string;
 		commandAddAssignableRoleExtended: string;
 		commandAddAssignableRole: (addedRoles: string[]) => string;


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR adds the wolfram command so Steve can do calculus. This does require a wolfram app id which can be gotten [here](https://products.wolframalpha.com/api/). Im also using `.then()` syntax because I dont want to deal with errors twice and axios will throw an error if the server responds with a 500 level error code. Only other change was that I added the `NASA` value to the config example because it was missing.
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [x] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
