### PR TITLE
Snooze reminders

### DIFF
--- a/src/commands/Productivity/setsnooze.ts
+++ b/src/commands/Productivity/setsnooze.ts
@@ -1,0 +1,21 @@
+import { SteveCommand } from '@lib/structures/commands/SteveCommand';
+import { GuildMessage } from '@lib/types/Messages';
+import { UserSettings } from '@lib/types/settings/UserSettings';
+import { ApplyOptions } from '@skyra/decorators';
+import { friendlyDuration } from '@utils/util';
+import { Message } from 'discord.js';
+import { CommandOptions } from 'klasa';
+
+@ApplyOptions<CommandOptions>({
+	description: lang => lang.tget('commandSetSnoozeDescription'),
+	usage: '<duration:timespan>'
+})
+export default class extends SteveCommand {
+
+	public async run(msg: GuildMessage, [duration]: [number]): Promise<Message> {
+		await msg.author.settings.update(UserSettings.SnoozeDuration, duration);
+
+		return msg.channel.send(msg.guild.language.tget('commandSetSnoozeSet', friendlyDuration(duration)));
+	}
+
+}

--- a/src/commands/Productivity/snooze.ts
+++ b/src/commands/Productivity/snooze.ts
@@ -1,0 +1,36 @@
+import { CommandOptions, KlasaMessage } from 'klasa';
+import { Message } from 'discord.js';
+import { ApplyOptions, CreateResolver } from '@skyra/decorators';
+import { UserSettings } from '@lib/types/settings/UserSettings';
+import { SteveCommand } from '@lib/structures/commands/SteveCommand';
+import { friendlyDuration } from '@utils/util';
+
+@ApplyOptions<CommandOptions>({
+	description: lang => lang.tget('commandSnoozeDescription'),
+	extendedHelp: lang => lang.tget('commandSnoozeExtended'),
+	usage: '(duration:timespan)'
+})
+@CreateResolver(
+	'timespan',
+	(str, possible, msg) => str
+		? msg.client.arguments.get('timespan').run(str, possible, msg)
+		: msg.author.settings.get(UserSettings.SnoozeDuration)
+)
+export default class extends SteveCommand {
+
+	public async run(msg: KlasaMessage, [duration]: [number]): Promise<Message> {
+		const reminder = this.client.schedule.getUserSnooze(msg.author.id);
+		if (!reminder) return msg.channel.send(msg.language.tget('commandSnoozeNoRemind'));
+
+		await this.client.schedule.createReminder(duration,
+			// @ts-expect-error 2339
+			reminder.data.userID ?? reminder.data.user, reminder.data.content,
+			// @ts-expect-error 2339
+			reminder.data.channelID ?? reminder.data.channel);
+
+		await reminder.delete();
+
+		return msg.channel.send(msg.language.tget('commandSnoozeCreated', reminder.data.content, friendlyDuration(duration)));
+	}
+
+}

--- a/src/extendables/Schedule.ts
+++ b/src/extendables/Schedule.ts
@@ -1,3 +1,4 @@
+import { Time } from '@lib/types/Enums';
 import { ApplyOptions } from '@skyra/decorators';
 import { Extendable, ExtendableOptions, Schedule, ScheduledTask } from 'klasa';
 
@@ -21,12 +22,26 @@ export default class extends Extendable {
 		});
 	}
 
+	public createSnooze(this: Schedule, userID: string, content: string, channelID: string): Promise<Reminder> {
+		return this.create('snooze', Date.now() + (5 * Time.MINUTE), {
+			catchUp: true,
+			data: { userID, content, channelID }
+		});
+	}
+
 	public getUserReminders(this: Schedule, userID: string): Reminder[] {
 		const filter = (task: ScheduledTask) => {
 			const id = task.data.userID ?? task.data.user;
 			return task.taskName === 'reminder' && id === userID;
 		};
 		return this.tasks.filter(filter);
+	}
+
+	public getUserSnooze(this: Schedule, userID: string): Reminder | undefined {
+		return this.tasks.filter((task: ScheduledTask) => {
+			const id = task.data.userID ?? task.data.user;
+			return task.taskName === 'snooze' && id === userID;
+		}).pop();
 	}
 
 }

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -817,7 +817,7 @@ export default class extends Language {
 		commandSnoozeCreated: (content, duration) => `I'll remind you **${content}** in ${duration}.`,
 		commandSnoozeNoRemind: 'It looks like you haven\'t had any reminders go off in the past 5 minutes.',
 		commandSetSnoozeDescription: 'Set your default snooze duration.',
-		commandSetSnoozeSet: (duration) => `Your default snooze duration is now ${duration}.`,
+		commandSetSnoozeSet: duration => `Your default snooze duration is now ${duration}.`,
 		/**
 		 * ################################
 		 * #      POMODORO                #

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -816,6 +816,8 @@ export default class extends Language {
 		}),
 		commandSnoozeCreated: (content, duration) => `I'll remind you **${content}** in ${duration}.`,
 		commandSnoozeNoRemind: 'It looks like you haven\'t had any reminders go off in the past 5 minutes.',
+		commandSetSnoozeDescription: 'Set your default snooze duration.',
+		commandSetSnoozeSet: (duration) => `Your default snooze duration is now ${duration}.`,
 		/**
 		 * ################################
 		 * #      POMODORO                #

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -805,6 +805,17 @@ export default class extends Language {
 		commandRemindViewEmbed: {
 			title: 'Pending Reminders'
 		},
+		commandSnoozeDescription: 'Repeat your last reminder.',
+		commandSnoozeExtended: builder.display('snooze', {
+			examples: [
+				'',
+				'5m'
+			],
+			reminder: 'You can only snooze reminders that happened in the past 5 minutes.',
+			extendedHelp: 'You can change your default snooze time with the `setsnooze` command.'
+		}),
+		commandSnoozeCreated: (content, duration) => `I'll remind you **${content}** in ${duration}.`,
+		commandSnoozeNoRemind: 'It looks like you haven\'t had any reminders go off in the past 5 minutes.',
 		/**
 		 * ################################
 		 * #      POMODORO                #

--- a/src/lib/schemas/User.ts
+++ b/src/lib/schemas/User.ts
@@ -1,4 +1,6 @@
+import { Time } from '@lib/types/Enums';
 import { Client } from 'klasa';
 
 export default Client.defaultUserSchema
-	.add('embedColor', 'Color');
+	.add('embedColor', 'Color')
+	.add('snoozeDuration', 'Integer', { 'default': 30 * Time.MINUTE });

--- a/src/lib/types/Augments.d.ts
+++ b/src/lib/types/Augments.d.ts
@@ -48,7 +48,9 @@ declare module 'klasa' {
 	interface Schedule {
 		createModerationTask(taskName: ModerationTask, duration: number, taskData: ModerationTaskData): Promise<ScheduledTask>;
 		createReminder(duration: number, userID: string, content: string, channelID: string): Promise<Reminder>;
+		createSnooze(userID: string, content: string, channelID: string): Promise<Reminder>;
 		getUserReminders(userID: string): Reminder[];
+		getUserSnooze(userID: string): Reminder;
 	}
 }
 

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -319,6 +319,10 @@ declare module 'klasa' {
 		commandRemindViewEmbed: {
 			title: string;
 		};
+		commandSnoozeDescription: string;
+		commandSnoozeExtended: string;
+		commandSnoozeNoRemind: string;
+		commandSnoozeCreated: (content: string, duration: string) => string;
 		commandPomodoroDescription: string;
 		commandPomodoroExtended: string;
 		commandPomodoroUnderConstruction: string;

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -323,6 +323,8 @@ declare module 'klasa' {
 		commandSnoozeExtended: string;
 		commandSnoozeNoRemind: string;
 		commandSnoozeCreated: (content: string, duration: string) => string;
+		commandSetSnoozeDescription: string;
+		commandSetSnoozeSet: (duration: string) => string;
 		commandPomodoroDescription: string;
 		commandPomodoroExtended: string;
 		commandPomodoroUnderConstruction: string;

--- a/src/lib/types/settings/UserSettings.ts
+++ b/src/lib/types/settings/UserSettings.ts
@@ -2,5 +2,6 @@
 export namespace UserSettings {
 
 	export const EmbedColor = 'embedColor';
+	export const SnoozeDuration = 'snoozeDuration';
 
 }

--- a/src/tasks/reminder.ts
+++ b/src/tasks/reminder.ts
@@ -2,6 +2,7 @@
 import { Task } from 'klasa';
 import { Message } from 'discord.js';
 import { OldReminderData, ReminderData } from '../extendables/Schedule';
+import { floatPromise } from '@utils/util';
 
 export default class extends Task {
 
@@ -11,7 +12,11 @@ export default class extends Task {
 		// @ts-expect-error 2339
 		const _user = await this.client.users.fetch(data.userID ?? data.user);
 
-		if (_channel && _channel.isText()) return _channel.send(`${_user}, here's the reminder you asked for: **${data.content}**`);
+		if (_channel && _channel.isText()) {
+			// @ts-expect-error 2339
+			floatPromise(this, this.client.schedule.createSnooze(data.userID ?? data.user, data.content, data.channelID ?? data.channel));
+			return _channel.send(`${_user}, here's the reminder you asked for: **${data.content}**`);
+		}
 	}
 
 }

--- a/src/tasks/snooze.ts
+++ b/src/tasks/snooze.ts
@@ -1,0 +1,11 @@
+
+import { Task } from 'klasa';
+import { OldReminderData, ReminderData } from '../extendables/Schedule';
+
+export default class extends Task {
+
+	public run(data: ReminderData | OldReminderData): ReminderData | OldReminderData {
+		return data;
+	}
+
+}


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
This PR gives users the ability to snooze recent reminders. If a reminder happened in the last five minutes, a user can use the `snooze` command to automatically schedule the same reminder again. They can either specify how long the repeat should take with an argument, or if given no args the command will use the users default snooze duration. Users can change their default duration using the `setsnooze` command or the `userconf` command for anyone who wants to ~~probably just me~~.
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [x] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
