### PR TITLE
tweak: remind view now uses embed description in place of fields

### DIFF
--- a/src/commands/Productivity/remind.ts
+++ b/src/commands/Productivity/remind.ts
@@ -1,6 +1,6 @@
 import { SteveCommand } from '@lib/structures/commands/SteveCommand';
 import { CommandOptions, KlasaMessage, RichDisplay } from 'klasa';
-import { ColorResolvable, EmbedField, Message, MessageEmbed, TextChannel } from 'discord.js';
+import { ColorResolvable, Message, MessageEmbed, TextChannel } from 'discord.js';
 import { GuildSettings } from '@lib/types/settings/GuildSettings';
 import { Reminder } from '@root/src/extendables/Schedule';
 import { UserSettings } from '@lib/types/settings/UserSettings';
@@ -64,18 +64,15 @@ export default class extends SteveCommand {
 			const display = new RichDisplay(this.buildViewEmbed(msg));
 
 			for (const page of chunk(reminders, 5)) {
-				const fields: EmbedField[] = [];
+				let content = '';
 
 				for (let i = 0; i < page.length; i++) {
 					const displayMessage = await this.getReminderDisplayContent(msg, page[i]);
-					fields.push({
-						name: `**${reminders.indexOf(page[i]) + 1}: ${displayMessage}**`,
-						value: embedData.fieldValues(this.getTimeUntilRemind(page[i])),
-						inline: false
-					});
+					content += `**${reminders.indexOf(page[i]) + 1}: ${displayMessage}**\n${
+						embedData.description(this.getTimeUntilRemind(page[i]))}\n\n`;
 				}
 
-				display.addPage((template: MessageEmbed) => template.addFields(fields));
+				display.addPage((template: MessageEmbed) => template.setDescription(content));
 			}
 
 			await display.run(response);
@@ -85,18 +82,15 @@ export default class extends SteveCommand {
 		const embeds: MessageEmbed[] = [];
 
 		for (const page of chunk(reminders, 25)) {
-			const fields: EmbedField[] = [];
+			let content = '';
 
 			for (let i = 0; i < page.length; i++) {
 				const displayMessage = await this.getReminderDisplayContent(msg, page[i]);
-				fields.push({
-					name: `**${reminders.indexOf(page[i]) + 1}: ${displayMessage}**`,
-					value: embedData.fieldValues(this.getTimeUntilRemind(page[i])),
-					inline: false
-				});
+				content += `**${reminders.indexOf(page[i]) + 1}: ${displayMessage}**\n${
+					embedData.description(this.getTimeUntilRemind(page[i]))}\n\n`;
 			}
 
-			embeds.push(this.buildViewEmbed(msg).addFields(fields));
+			embeds.push(this.buildViewEmbed(msg).setDescription(content));
 		}
 		embeds.reverse();
 

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -805,7 +805,7 @@ export default class extends Language {
 		commandReminderDisplayHidden: 'Private reminder: content hidden',
 		commandRemindViewEmbed: {
 			title: 'Pending Reminders',
-			fieldValues: time => `${time} left!`
+			description: time => `${time} left!`
 		},
 		/**
 		 * ################################

--- a/src/lib/types/Languages.d.ts
+++ b/src/lib/types/Languages.d.ts
@@ -319,7 +319,7 @@ declare module 'klasa' {
 		commandReminderDisplayHidden: string;
 		commandRemindViewEmbed: {
 			title: string;
-			fieldValues: (time: string) => string;
+			description: (time: string) => string;
 		};
 		commandPomodoroDescription: string;
 		commandPomodoroExtended: string;


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
Ench asked me to fix this, so I did.
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [x] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [ ] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
