### PR TITLE
Update discordstatus command to use new logo & color

### DIFF
--- a/src/commands/Miscellaneous/discordstatus.ts
+++ b/src/commands/Miscellaneous/discordstatus.ts
@@ -64,7 +64,7 @@ export default class extends SteveCommand {
 			.setThumbnail(ImageAssets.DiscordLogo)
 			.setTimestamp()
 			.setFooter(embedData.footer(formatDate(new Date(currentStatus.page.updated_at))))
-			.setColor('BLURPLE');
+			.setColor(0x5865F2);
 
 		return response.edit(undefined, embed);
 

--- a/src/lib/types/Enums.d.ts
+++ b/src/lib/types/Enums.d.ts
@@ -22,7 +22,7 @@ export const enum Emojis {
 export const enum ImageAssets {
 	AlarmClock = 'https://stevebot.xyz/steveassets/alarmclock.png',
 	Cat = 'https://stevebot.xyz/steveassets/animals/cat.png',
-	DiscordLogo = 'https://discord.com/assets/2c21aeda16de354ba5334551a883b481.png',
+	DiscordLogo = 'https://discord.com/assets/f9bb9c4af2b9c32a2c5ee0014661546d.png',
 	Dog = 'https://stevebot.xyz/steveassets/animals/dog.png',
 	Fox = 'https://stevebot.xyz/steveassets/animals/fox.png',
 	NodeJs = 'https://stevebot.xyz/steveassets/nodejs.png'


### PR DESCRIPTION
**Describe this PR and why it should be merged:**
Discord changed their branding and so this PR updates the `discordstatus` command to use the new clyde logo and the new ~~uglier~~ blurple.
**Status**
- [x] This PR has been tested and complies with this project's ESLint rules
- [x] This PR adds/modifes a command

**Semantic Versioning**
- [ ] This PR features bug fixes, or only style changes/refactorings, or no code changes
- [ ] This PR adds features for users
- [ ] This PR switches this project to a new a new Discord API library/new Discord.js framework
